### PR TITLE
Strip prefix of opening fence from closing fence line (#1)

### DIFF
--- a/dev/lib/math-flow.js
+++ b/dev/lib/math-flow.js
@@ -295,7 +295,7 @@ function tokenizeMathFenced(effects, ok, nok) {
       effects,
       beforeSequenceClose,
       types.linePrefix,
-      constants.tabSize
+      initialSize ? initialSize + 1 : constants.tabSize
     )
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -263,6 +263,28 @@ test('markdown -> html (micromark)', () => {
   )
 
   assert.equal(
+    micromark('      $$\n      a\n      $$', {
+      extensions: [syntax(), {disable: {null: ['codeIndented']}}],
+      htmlExtensions: [html()]
+    }),
+    '<div class="math math-display">' +
+      renderToString('a', {displayMode: true}) +
+      '</div>',
+    'should strip the prefix of the opening fence from closing fence line (codeIndented disabled)'
+  )
+
+  assert.throws(
+    () => {
+      micromark('      $$\n      a\n       $$', {
+        extensions: [syntax(), {disable: {null: ['codeIndented']}}],
+        htmlExtensions: [html()]
+      })
+    },
+    /KaTeX parse error: Can't use function '\$' in math mode at position 4/,
+    'should not tolerate a longer prefix in closing fence line than used in opening fence line (codeIndented disabled)'
+  )
+
+  assert.equal(
     micromark('> $$\n> a\n> $$\n> b', {
       extensions: [syntax()],
       htmlExtensions: [html()]


### PR DESCRIPTION
The problem occurs only when construct codeIndented is disabled, as is the case with micromark-extension-mdx-md.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Strip whitespace from closing fence line the same way it's done with content lines. This enables to parse indented display math when construct `codeIndented` is disabled.

This PR (`1-prefixed-closing-fence-a`) requires the length of the whitespace prefix on the closing fence line to be equal (or less) as on the opening fence line.

An alternate version exists in [1-prefixed-closing-fence-b](https://github.com/tumidi/micromark-extension-math/commit/02a60e84871af858f6b5e682fb169db148e81d18) which behaves as [`codeFenced`](https://github.com/micromark/micromark/blob/ce3593ae2f5ff549d9d4445193d950b9a9e95189/packages/micromark-core-commonmark/dev/lib/code-fenced.js#L209-L211). It allows for arbitrary length whitespace prefix on the closing fence line.

I think this version `1-prefixed-closing-fence-a` makes more sense as it treats the closing fence line the same way as content lines. But I might have missed the purpose of this behavior in `codeFenced` hence the two versions.

<!--do not edit: pr-->
