### PR TITLE
Add support for arbitrary indent when w/o `codeIntended`

### DIFF
--- a/dev/lib/math-flow.js
+++ b/dev/lib/math-flow.js
@@ -295,7 +295,9 @@ function tokenizeMathFenced(effects, ok, nok) {
       effects,
       beforeSequenceClose,
       types.linePrefix,
-      constants.tabSize
+      self.parser.constructs.disable.null.includes('codeIndented')
+        ? undefined
+        : constants.tabSize
     )
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -263,6 +263,17 @@ test('markdown -> html (micromark)', () => {
   )
 
   assert.equal(
+    micromark('      $$\n      a\n          $$', {
+      extensions: [syntax(), {disable: {null: ['codeIndented']}}],
+      htmlExtensions: [html()]
+    }),
+    '<div class="math math-display">' +
+      renderToString('a', {displayMode: true}) +
+      '</div>',
+    'should strip arbitrary length prefix from closing fence line (codeIndented disabled)'
+  )
+
+  assert.equal(
     micromark('> $$\n> a\n> $$\n> b', {
       extensions: [syntax()],
       htmlExtensions: [html()]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Allows for arbitrary length whitespace prefix on the closing fence line.

<!--do not edit: pr-->
